### PR TITLE
Fixed compilation warning and removed memory leak TODO

### DIFF
--- a/main.c
+++ b/main.c
@@ -47,8 +47,7 @@ void print_usage() {
 void parse_args(const int argc, const char *argv[]) {
 	int opt;
 	strcat(FOLDER_NAME, argv[1]);
-	// TODO : This throws an annoying warning right now
-	while((opt = getopt(argc, argv, "t:f:h")) != -1) {
+	while((opt = getopt(argc, (char**)argv, "t:f:h")) != -1) {
 		switch(opt) {
 			// TODO : This will probably end up bloating the main file after a while
 			// consider moving parse_args into another file

--- a/main.c
+++ b/main.c
@@ -94,8 +94,6 @@ void set_atoms() {
 
 // From setroot.c, sets a pixmap to be root
 // Commented out some stuff that is handled elsewhere
-// TODO : I'm unsure if the nested if cases are needed,
-// However I'm scared that deleting them will cause some memory leak within X
 void
 set_pixmap_property(Pixmap p)
 {


### PR DESCRIPTION
- Casting `argv` to remove the `const` in an explicit way when passing it to `getopt` makes the compiler happy.
- I tried commenting out the ifs in question and running the program through Valgrind, revealing leaks when doing so (Actually removing `if (data_esetroot) { free(data_esetroot); }` in particular did not cause a leak, but I'm guessing that's because `type`  didn't match `XA_PIXMAP`)

Valgrind report when commenting both ifs:

```
==8984== Memcheck, a memory error detector
==8984== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==8984== Using Valgrind-3.16.1 and LibVEX; rerun with -h for copyright info
==8984== Command: ./debug imgs/ -f %05d.jpeg
==8984==
^CReceived Interrupt. Exiting...
==8984==
==8984== HEAP SUMMARY:
==8984==     in use at exit: 87,673 bytes in 315 blocks
==8984==   total heap usage: 3,690 allocs, 3,375 frees, 379,852,015 bytes allocated
==8984==
==8984== 972 bytes in 108 blocks are definitely lost in loss record 81 of 89
==8984==    at 0x483879F: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==8984==    by 0x4890EE6: XGetWindowProperty (in /usr/lib64/libX11.so.6.4.0)
==8984==    by 0x109663: set_pixmap_property (main.c:107)
==8984==    by 0x109DB5: main (main.c:249)
==8984==
==8984== LEAK SUMMARY:
==8984==    definitely lost: 972 bytes in 108 blocks
==8984==    indirectly lost: 0 bytes in 0 blocks
==8984==      possibly lost: 0 bytes in 0 blocks
==8984==    still reachable: 86,701 bytes in 207 blocks
==8984==         suppressed: 0 bytes in 0 blocks
==8984== Reachable blocks (those to which a pointer was found) are not shown.
==8984== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==8984==
==8984== For lists of detected and suppressed errors, rerun with: -s
==8984== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```