### PR TITLE
Move image loading to avoid all memory usage

### DIFF
--- a/main.c
+++ b/main.c
@@ -168,6 +168,8 @@ Pixmap *load_pixmaps_from_images(const Imlib_Image *images, const int amount)
 		imlib_context_set_drawable(*(temp+i));
 		imlib_context_set_image(*(images+i));
 		imlib_render_image_on_drawable(0, 0);
+		imlib_context_set_image(images[i]);
+		imlib_free_image();
 	}
 	return temp;
 }
@@ -229,11 +231,6 @@ int main(int argc, const char *argv[])
 	if (!pixmaps) {
 		printf("Failed to initialize pixmaps\n");
 		exit(1);
-	}
-
-	for (int i = 0; i < NUMBER_OF_FRAMES; i++) {
-		imlib_context_set_image(entries[i]);
-		imlib_free_image();
 	}
 
 	int current = 0;


### PR DESCRIPTION
I moved some imlib loading and image freeing into the pixmaps load loop.
This reduces memory usage during load to almost nothing (compared to 15Gb+ when using a 1Gb folder before).
This allows me to load 2Gb worth of images with my pc performance being completely unaffected.

Here's a demonstration:
https://vimeo.com/582352185
CPU and memory usage is from recording and everything is smooth as butter when not recording