### PR TITLE
"imlib2-config" remove fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 asetroot: main.c
-	gcc -o asetroot main.c -lX11 `imlib2-config --cflags` `imlib2-config --libs` -Wall -O3
+        gcc -o asetroot main.c -lX11 `pkg-config --cflags imlib2` `pkg-config --libs imlib2` -Wall -O3
 
 debug: main.c
-	gcc -o debug main.c -lX11 `imlib2-config --cflags` `imlib2-config --libs` -Wall -g -O0
+        gcc -o debug main.c -lX11 `pkg-config --cflags imlib2` `pkg-config --libs imlib2` -Wall -g -O0


### PR DESCRIPTION
Since imlib2-config has been removed, makefile has to be changed to use pkg-config.

Works on my machine.

#8 issue.

@Wilnath